### PR TITLE
Feature/Scene state manager

### DIFF
--- a/client/core/src/com/anything/tacticool/view/scene/GameView.java
+++ b/client/core/src/com/anything/tacticool/view/scene/GameView.java
@@ -2,7 +2,4 @@ package com.anything.tacticool.view.scene;
 
 public class GameView extends Scene {
 
-    protected GameView(SceneManager sm) {
-        super(sm);
-    }
 }

--- a/client/core/src/com/anything/tacticool/view/scene/GameView.java
+++ b/client/core/src/com/anything/tacticool/view/scene/GameView.java
@@ -1,0 +1,8 @@
+package com.anything.tacticool.view.scene;
+
+public class GameView extends Scene {
+
+    protected GameView(SceneManager sm) {
+        super(sm);
+    }
+}

--- a/client/core/src/com/anything/tacticool/view/scene/MainView.java
+++ b/client/core/src/com/anything/tacticool/view/scene/MainView.java
@@ -1,0 +1,8 @@
+package com.anything.tacticool.view.scene;
+
+public class MainView extends Scene {
+
+    protected MainView(SceneManager sm) {
+        super(sm);
+    }
+}

--- a/client/core/src/com/anything/tacticool/view/scene/MainView.java
+++ b/client/core/src/com/anything/tacticool/view/scene/MainView.java
@@ -2,7 +2,4 @@ package com.anything.tacticool.view.scene;
 
 public class MainView extends Scene {
 
-    protected MainView(SceneManager sm) {
-        super(sm);
-    }
 }

--- a/client/core/src/com/anything/tacticool/view/scene/Scene.java
+++ b/client/core/src/com/anything/tacticool/view/scene/Scene.java
@@ -3,5 +3,7 @@ package com.anything.tacticool.view.scene;
 import com.badlogic.gdx.ApplicationAdapter;
 
 public abstract class Scene extends ApplicationAdapter {
+    protected SceneManager sm;
 
+    protected Scene(SceneManager sm){this.sm = sm;}
 }

--- a/client/core/src/com/anything/tacticool/view/scene/Scene.java
+++ b/client/core/src/com/anything/tacticool/view/scene/Scene.java
@@ -5,5 +5,5 @@ import com.badlogic.gdx.ApplicationAdapter;
 public abstract class Scene extends ApplicationAdapter {
     protected SceneManager sm;
 
-    protected Scene(SceneManager sm){this.sm = sm;}
+    protected Scene(){this.sm = SceneManager.getInstance();}
 }

--- a/client/core/src/com/anything/tacticool/view/scene/Scene.java
+++ b/client/core/src/com/anything/tacticool/view/scene/Scene.java
@@ -1,0 +1,7 @@
+package com.anything.tacticool.view.scene;
+
+import com.badlogic.gdx.ApplicationAdapter;
+
+public abstract class Scene extends ApplicationAdapter {
+
+}

--- a/client/core/src/com/anything/tacticool/view/scene/SceneManager.java
+++ b/client/core/src/com/anything/tacticool/view/scene/SceneManager.java
@@ -1,0 +1,17 @@
+package com.anything.tacticool.view.scene;
+
+import java.util.Stack;
+
+public class SceneManager {
+    private Stack<Scene> scenes;
+
+    public SceneManager(){
+        scenes = new Stack<>();
+    }
+
+    public void push(Scene scene){
+        scenes.pop();
+        scenes.push(scene);
+    }
+
+}

--- a/client/core/src/com/anything/tacticool/view/scene/SceneManager.java
+++ b/client/core/src/com/anything/tacticool/view/scene/SceneManager.java
@@ -40,7 +40,7 @@ public class SceneManager {
 
     public Scene Peek(){
         if (scenes.empty()){
-            throw new IllegalStateException("No Scenes to peek at in Stack.");
+            throw new IllegalStateException("No Scenes to peek at in stack.");
         }
         return scenes.peek();
     }

--- a/client/core/src/com/anything/tacticool/view/scene/SceneManager.java
+++ b/client/core/src/com/anything/tacticool/view/scene/SceneManager.java
@@ -3,15 +3,45 @@ package com.anything.tacticool.view.scene;
 import java.util.Stack;
 
 public class SceneManager {
-    private Stack<Scene> scenes;
 
-    public SceneManager(){
+    private static Stack<Scene> scenes;
+
+    //Singleton boilerplate begins
+    public static volatile SceneManager Singleton;
+
+    private SceneManager(){
+        if (Singleton != null){
+            throw new RuntimeException("Singleton somehow already created, use SceneManager.getInstance() instead.");
+        }
         scenes = new Stack<>();
     }
 
-    public void push(Scene scene){
-        scenes.pop();
+    public static SceneManager getInstance() {
+        if (Singleton == null) {
+            synchronized (SceneManager.class) {
+                if (Singleton == null) Singleton = new SceneManager();
+            }
+        }
+        return Singleton;
+    }
+    //Singleton boilerplate ends
+
+    //Stack handling functions
+    public void Push(Scene scene){
         scenes.push(scene);
     }
 
+    public Scene Pop(){
+        if (scenes.empty()){
+            throw new IllegalStateException("Can't pop scene from stack when stack is empty.");
+        }
+        return scenes.pop();
+    }
+
+    public Scene Peek(){
+        if (scenes.empty()){
+            throw new IllegalStateException("No Scenes to peek at in Stack.");
+        }
+        return scenes.peek();
+    }
 }

--- a/client/core/src/com/anything/tacticool/view/scene/SceneManager.java
+++ b/client/core/src/com/anything/tacticool/view/scene/SceneManager.java
@@ -32,14 +32,14 @@ public class SceneManager {
     }
 
     public Scene Pop(){
-        if (scenes.empty()){
+        if (scenes.isEmpty()){
             throw new IllegalStateException("Can't pop scene from stack when stack is empty.");
         }
         return scenes.pop();
     }
 
     public Scene Peek(){
-        if (scenes.empty()){
+        if (scenes.isEmpty()){
             throw new IllegalStateException("No Scenes to peek at in stack.");
         }
         return scenes.peek();

--- a/client/core/src/com/anything/tacticool/view/scene/Settings.java
+++ b/client/core/src/com/anything/tacticool/view/scene/Settings.java
@@ -2,7 +2,4 @@ package com.anything.tacticool.view.scene;
 
 public class Settings extends Scene {
 
-    protected Settings(SceneManager sm) {
-        super(sm);
-    }
 }

--- a/client/core/src/com/anything/tacticool/view/scene/Settings.java
+++ b/client/core/src/com/anything/tacticool/view/scene/Settings.java
@@ -1,0 +1,8 @@
+package com.anything.tacticool.view.scene;
+
+public class Settings extends Scene {
+
+    protected Settings(SceneManager sm) {
+        super(sm);
+    }
+}


### PR DESCRIPTION
Added an abstract Class Scene from which different View scenes should inherit from.  Added a basic SceneManager Singleton that handles scenes as a Stack. Added basic Scene classes based on the Activity Diagram architectural view.

The reasonings for these implementations are:
- Handling different contexts for the client View as scenes helps with atomizing, and provides a better framework to update only the active scene. Updating the View this way additionally creates very little overhead, as peek(), push(), pop() and isEmpty() operations take O(1) time.
- SceneManager should be accessible at any point from the client View, and there should only be one. Thus it should be a Singleton.
- Handling scenes as a stack allows for better usability, as it allows for easy "backtracking" to the previous scene.