### PR TITLE
Fixed bug where music wouldn't stop playing when Popping SceneManager…

### DIFF
--- a/client/core/src/com/anything/tacticool/view/scene/GameView.java
+++ b/client/core/src/com/anything/tacticool/view/scene/GameView.java
@@ -240,7 +240,7 @@ public class GameView extends Scene {
     private void post() throws IOException{
         request.postMoves(new Serializer().serializeActions(ap.inputs), gameID, playerID);
         this.isWaiting = true;
-        // Diasble UI
+        // Disable UI
         for (Actor actor : stage.getActors()) {
             actor.setVisible(false);
         }

--- a/client/core/src/com/anything/tacticool/view/scene/SceneManager.java
+++ b/client/core/src/com/anything/tacticool/view/scene/SceneManager.java
@@ -51,6 +51,7 @@ public class SceneManager {
         if (scenes.isEmpty()){
             throw new IllegalStateException("Can't pop scene from stack when stack is empty.");
         }
+        scenes.peek().disposeEarly();
         Scene poppedScene = scenes.pop();
         if (!scenes.isEmpty()) {
             scenes.peek().prepareScene();


### PR DESCRIPTION
… twice.

Added line to SceneManager to call a scene's disposeEarly function, so that the scene can actually dispose when it is popped, not only when another is pushed on top of it